### PR TITLE
Add atsign-showfl, a lower-overhead version of atsign-showln

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,10 +12,29 @@ function foo()
     nothing
 end
 
+# The more laborious approach, in case one needs speed
+function foofl()
+    x = 5
+    @showfl(@__FILE__, @__LINE__, x)
+    x = 7
+    @showfl(@__FILE__, @__LINE__, x)
+    nothing
+end
+
 foo()
 
 str = chomp(takebuf_string(io))
 target = ("x = 5", "(in foo at", "x = 7", "(in foo at")
+for (i,ln) in enumerate(split(str, '\n'))
+    ln = lstrip(ln)
+    @test startswith(ln, target[i])
+end
+
+io = IOBuffer()
+DebuggingUtilities.showlnio[] = io
+foofl()
+str = chomp(takebuf_string(io))
+target = ("x = 5", "(at file ", "x = 7", "(at file ")
 for (i,ln) in enumerate(split(str, '\n'))
     ln = lstrip(ln)
     @test startswith(ln, target[i])


### PR DESCRIPTION
Follows up on the suggestion in https://github.com/timholy/DebuggingUtilities.jl/commit/dbb621b0b82ba09da79d5c2cecd9da2891263b2d#commitcomment-17046790.

Not as convenient to use, but it doesn't require collecting and analyzing backtraces.
