### PR TITLE
Use `__source__` and prepare for registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+          - windows-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DebuggingUtilities"
 uuid = "5a34b05b-6094-51df-87c5-5e0368a91250"
 authors = ["Tim Holy"]
-version = "0.1.0"
+version = "1.0.0"
 
 [deps]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package contains simple utilities that may help debug julia code.
 
 Install with
 
-```jl
+```julia
 pkg> dev https://github.com/timholy/DebuggingUtilities.jl.git
 ```
 
@@ -23,7 +23,7 @@ DebuggingUtilities as a dependency use `project> dev DebuggingUtilities`.
 statement was executed. This can be useful when variables change value
 in the course of a single function. For example:
 
-```jl
+```julia
 using DebuggingUtilities
 
 function foo()
@@ -34,13 +34,61 @@ function foo()
     nothing
 end
 ```
+
 might, when called (`foo()`), produce output like
+
 ```
-            x = 5
-            (in foo at ./error.jl:26 at /tmp/showln_test.jl:5)
-            x = 7
-            (in foo at ./error.jl:26 at /tmp/showln_test.jl:7)
+x = 5
+(in /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:5)
+x = 7
+(in /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:7)
+7
 ```
+
+## @showlnt
+
+`@showlnt` is for recursion, and uses indentation to show nesting depth.
+For example,
+
+```julia
+function recurses(n)
+    @showlnt n
+    n += 1
+    @showlnt n
+    if n < 10
+        n = recurses(n+1)
+    end
+    return n
+end
+```
+
+might, when called as `recurses(1)`, generate
+
+```
+                                 n = 1
+                                 (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:10)
+                                 n = 2
+                                 (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:12)
+                                  n = 3
+                                  (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:10)
+                                  n = 4
+                                  (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:12)
+                                   n = 5
+                                   (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:10)
+                                   n = 6
+                                   (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:12)
+                                    n = 7
+                                    (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:10)
+                                    n = 8
+                                    (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:12)
+                                     n = 9
+                                     (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:10)
+                                     n = 10
+                                     (in recurses at /home/tim/.julia/dev/DebuggingUtilities/test/funcdefs.jl:12)
+```
+
+Each additional space indicates one additional layer in the call chain.
+Most of the initial space (even for `n=1`) is due to Julia's own REPL.
 
 ## test_showline
 

--- a/test/funcdefs.jl
+++ b/test/funcdefs.jl
@@ -1,0 +1,17 @@
+# Note: tests are sensitive to the line numbers of statements below
+function foo()
+    x = 5
+    @showln x
+    x = 7
+    @showln x
+end
+
+function recurses(n)
+    @showlnt n
+    n += 1
+    @showlnt n
+    if n < 10
+        n = recurses(n+1)
+    end
+    return n
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,49 +1,54 @@
 using DebuggingUtilities
 using Test
 
-function foo()
-    x = 5
-    @showln x
-    x = 7
-    @showln x
+include("funcdefs.jl")
+funcdefs_path = joinpath(@__DIR__, "funcdefs.jl")
+
+@testset "DebuggingUtilities" begin
+    io = IOBuffer()
+    DebuggingUtilities.showlnio[] = io
+
+    @test foo() == 7
+
+    str = chomp(String(take!(io)))
+    target = ("x = 5", "(in $funcdefs_path:4)", "x = 7", "(in $funcdefs_path:6)")
+    for (i,ln) in enumerate(split(str, '\n'))
+        ln = lstrip(ln)
+        @test ln == target[i]
+    end
+
+    @test recurses(1) == 10
+    str = chomp(String(take!(io)))
+    lines = split(str, '\n')
+    offset = lstrip(lines[1]).offset
+    for i = 1:5
+        j = 2*i-1
+        k = 4*i-3
+        ln = String(lines[k])
+        lns = lstrip(ln)
+        @test lns.offset == offset + i - 1
+        @test lns == "n = $j"
+        ln = String(lines[k+1])
+        lns = lstrip(ln)
+        @test lns.offset == offset + i - 1
+        @test lns == "(in recurses at $funcdefs_path:10)"
+        j += 1
+        ln = String(lines[k+2])
+        lns = lstrip(ln)
+        @test lns.offset == offset + i - 1
+        @test lns == "n = $j"
+        ln = String(lines[k+3])
+        lns = lstrip(ln)
+        @test lns.offset == offset + i - 1
+        @test lns == "(in recurses at $funcdefs_path:12)"
+    end
+
+    # Just make sure these run
+    io = IOBuffer()
+    DebuggingUtilities.showlnio[] = io
+    test_showline("noerror.jl")
+    @test_throws DomainError test_showline("error.jl")
+    time_showline("noerror.jl")
+
+    DebuggingUtilities.showlnio[] = stdout
 end
-
-# The more laborious approach, in case one needs speed
-function foofl()
-    x = 5
-    @showfl(@__FILE__, @__LINE__, x)
-    x = 7
-    @showfl(@__FILE__, @__LINE__, x)
-end
-
-io = IOBuffer()
-DebuggingUtilities.showlnio[] = io
-
-@test foo() == 7
-
-str = chomp(String(take!(io)))
-target = ("x = 5", "(in foo at", "x = 7", "(in foo at")
-for (i,ln) in enumerate(split(str, '\n'))
-    ln = lstrip(ln)
-    @test startswith(ln, target[i])
-end
-
-io = IOBuffer()
-DebuggingUtilities.showlnio[] = io
-@test foofl() == 7
-str = chomp(String(take!(io)))
-target = ("x = 5", "(at file ", "x = 7", "(at file ")
-for (i,ln) in enumerate(split(str, '\n'))
-    ln = lstrip(ln)
-    @test startswith(ln, target[i])
-end
-
-# Just make sure these run
-io = IOBuffer()
-DebuggingUtilities.showlnio[] = io
-test_showline("noerror.jl")
-@test_throws DomainError test_showline("error.jl")
-time_showline("noerror.jl")
-
-DebuggingUtilities.showlnio[] = stdout
-nothing


### PR DESCRIPTION
xref https://discourse.julialang.org/t/showln-in-base/46957

The big difference is that `@showfl` has improved and become `@showln` (it's the better name) and the old `@showln` has become `@showlnt` (the `t` stands for "trace" as in backtrace). Basically, this package was written before we had `__source__`, and having it makes the package possible in the way it was originally intended.

Closes #9